### PR TITLE
Update go-hibp with breaking changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/turbot/steampipe-plugin-sdk/v4 v4.1.7
-	github.com/wneessen/go-hibp v1.0.3
+	github.com/wneessen/go-hibp v1.0.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -425,6 +425,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wneessen/go-hibp v1.0.3 h1:7T5tAoqre6+A4CdZRXZb9VbxWCcdzr+BdskyghxpaME=
 github.com/wneessen/go-hibp v1.0.3/go.mod h1:Ldg6DQg4fMCveVKgL+RL9Jy+9TsljjAP704Ix8X3jOw=
+github.com/wneessen/go-hibp v1.0.4 h1:G/DPSu30FD/M/JFqFK+2512z3OilCUF1LdQnB8Xzx5g=
+github.com/wneessen/go-hibp v1.0.4/go.mod h1:Ldg6DQg4fMCveVKgL+RL9Jy+9TsljjAP704Ix8X3jOw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/hibp/client.go
+++ b/hibp/client.go
@@ -53,9 +53,9 @@ func getKeysFromConfig(ctx context.Context, d *plugin.QueryData) (apiKey string,
 
 func createClient(ctx context.Context, apiKey string) *hibp.Client {
 	clientOptions := []hibp.Option{
-		hibp.WithApiKey(apiKey),
+		hibp.WithAPIKey(apiKey),
 		hibp.WithUserAgent("Turbot Steampipe (+https://steampipe.io)"),
-		hibp.WithHttpTimeout(3 * time.Second),
+		hibp.WithHTTPTimeout(3 * time.Second),
 		hibp.WithRateLimitSleep(),
 	}
 

--- a/hibp/table_hibp_breach.go
+++ b/hibp/table_hibp_breach.go
@@ -41,7 +41,7 @@ func listBreaches(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		requestOptions = append(requestOptions, hibp.WithDomain(val.GetStringValue()))
 	}
 
-	breaches, _, err := client.BreachApi.Breaches(requestOptions...)
+	breaches, _, err := client.BreachAPI.Breaches(requestOptions...)
 
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func getBreach(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	quals := d.KeyColumnQuals
 	name := quals["name"].GetStringValue()
 
-	breach, _, err := client.BreachApi.BreachByName(name)
+	breach, _, err := client.BreachAPI.BreachByName(name)
 	if err != nil {
 		return nil, err
 	}

--- a/hibp/table_hibp_breached_account.go
+++ b/hibp/table_hibp_breached_account.go
@@ -57,7 +57,7 @@ func listBreachedAccounts(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		requestOptions = append(requestOptions, hibp.WithDomain(val.GetStringValue()))
 	}
 
-	breaches, _, err := client.BreachApi.BreachedAccount(account, requestOptions...)
+	breaches, _, err := client.BreachAPI.BreachedAccount(account, requestOptions...)
 
 	if err != nil {
 		return nil, err

--- a/hibp/table_hibp_password.go
+++ b/hibp/table_hibp_password.go
@@ -3,6 +3,7 @@ package hibp
 import (
 	"context"
 	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,8 +49,8 @@ func listPasswords(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 			return nil, fmt.Errorf("'hash' must be exactly 40 characters hexadecimal")
 		}
 		// make sure that this is a valid hex string
-		_, err := strconv.ParseUint(hash, 16, 64)
-		if err != nil {
+		dst := make([]byte, hex.DecodedLen(len(hash)))
+		if _, err := hex.Decode(dst, []byte(hash)); err != nil {
 			return nil, fmt.Errorf("'hash' is not a valid SHA-1 hash")
 		}
 		hashPrefixToSearch = hash

--- a/hibp/table_hibp_password.go
+++ b/hibp/table_hibp_password.go
@@ -68,7 +68,7 @@ func listPasswords(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		hashPrefixToSearch = fmt.Sprintf("%x", sha1.Sum([]byte(d.KeyColumnQualString("plaintext"))))
 	}
 
-	matches, _, err := client.PwnedPassApi.ListHashesPrefix(hashPrefixToSearch[:5])
+	matches, _, err := client.PwnedPassAPI.ListHashesPrefix(hashPrefixToSearch[:5])
 	if err != nil {
 		return nil, err
 	}

--- a/hibp/table_hibp_paste.go
+++ b/hibp/table_hibp_paste.go
@@ -35,7 +35,7 @@ func listPastes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 	}
 
 	quals := d.KeyColumnQuals
-	pastes, _, err := client.PasteApi.PastedAccount(quals["account"].GetStringValue())
+	pastes, _, err := client.PasteAPI.PastedAccount(quals["account"].GetStringValue())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR updates go-hibp to v1.0.4.

The underlying library https://github.com/wneessen/go-hibp has just been updated to v1.0.4, which introduced some breaking changes (see: https://github.com/wneessen/go-hibp/releases/tag/v1.0.4). Since I knew this module uses go-hibp, I've updated the changes accordingly.