### PR TITLE
Update hibp_password and hibp_breach tables to work without an API key closes #9

### DIFF
--- a/config/hibp.spc
+++ b/config/hibp.spc
@@ -1,8 +1,9 @@
 connection "hibp" {
   plugin  = "hibp"
 
-  # Requests to HIBP API needs to carry an API key.
-  # See https://haveibeenpwned.com/API/Key for more information on how to generate one
+  # `api_key` - The API key to access the HIBP API. 
+  # This is only required while querying `hibp_breached_account` and `hibp_paste` tables. 
   # This can also be set with the 'HIBP_API_KEY' environment variable
+  # See https://haveibeenpwned.com/API/Key for more information on how to generate one
   # api_key = "03ef6bfxxxxxxxxxxxxxxx8ad568286b"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,13 +68,15 @@ Installing the latest hibp plugin will create a config file (`~/.steampipe/confi
 connection "hibp" {
   plugin  = "hibp"
 
-  # Requests to HIBP API needs to carry an API KEY.
-  # You can get one at https://haveibeenpwned.com/API/Key
+  # `api_key` - The API key to access the HIBP API. 
+  # This is only required while querying `hibp_breached_account` and `hibp_paste` tables. 
+  # This can also be set with the 'HIBP_API_KEY' environment variable
+  # See https://haveibeenpwned.com/API/Key for more information on how to generate one
   # api_key = "03ef6bfxxxxxxxxxxxxxxx8ad568286b"
 }
 ```
 
-- `api_key` - The API key to access the HIBP API. Can also be set with the `HIBP_API_KEY` environment variable. This is only required while querying `hibp_breached_account` and `hibp_paste` tables. However, you do not need an API key to query `hibp_breach` and `hibp_password` tables.
+- `api_key` - The API key to access the HIBP API. Can also be set with the `HIBP_API_KEY` environment variable. This is only required while querying `hibp_breached_account` and `hibp_paste` tables.
 
 ## Get involved
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ select
 from
   hibp_breach
 where
-  breach_date > '2022-01-01'
+  breach_date > '2022-01-01';
 ```
 
 ```
@@ -74,7 +74,7 @@ connection "hibp" {
 }
 ```
 
-- `api_key` - (required) The API key to access the HIBP API. Can also be set with the `HIBP_API_KEY` environment variable.
+- `api_key` - The API key to access the HIBP API. Can also be set with the `HIBP_API_KEY` environment variable. This is only required while querying `hibp_breached_account` and `hibp_paste` tables. However, you do not need an API key to query `hibp_breach` and `hibp_password` tables.
 
 ## Get involved
 

--- a/docs/tables/hibp_breach.md
+++ b/docs/tables/hibp_breach.md
@@ -1,6 +1,8 @@
-# Table: hibp_breached_account
+# Table: hibp_breach
 
 A "breach" is an instance of a system having been compromised by an attacker and the data disclosed. For example, Adobe was a breach, Gawker was a breach etc. This returns the details of each of breach in the system which currently stands at 606 breaches.
+
+This table does not require an API key to be configured in the `hibp.spc` file.
 
 ## Examples
 

--- a/docs/tables/hibp_breached_account.md
+++ b/docs/tables/hibp_breached_account.md
@@ -1,4 +1,4 @@
-# Table: hibp_account
+# Table: hibp_breached_account
 
 The most common use of the API is to return a list of all breaches a particular account has been involved in. This table returns data similar to the `hibp_breach` table, with the requirement and addition of an `account` field.
 

--- a/docs/tables/hibp_breached_account.md
+++ b/docs/tables/hibp_breached_account.md
@@ -4,6 +4,8 @@ The most common use of the API is to return a list of all breaches a particular 
 
 While the `hibp_breaches` table will return all of the known breaches, this table can be used to find breaches for a particular account.
 
+This table requires an API key to be configured in the `hibp.spc` file.
+
 ## Examples
 
 ### List breaches from the last 3 months for an account

--- a/docs/tables/hibp_password.md
+++ b/docs/tables/hibp_password.md
@@ -4,6 +4,8 @@ Pwned Passwords are more than half a billion passwords which have previously bee
 
 You can search by providing the `plaintext` password or the `hash` - which is the `SHA-1` hash of the password that you are looking for. Alternatively, you can also search by the `hash_prefix` which is a prefix (at least 5 hex-digits) of the `SHA-1` password.
 
+This table does not require an API key to be configured in the `hibp.spc` file.
+
 ## Examples
 
 ### Get the number of times a password hash has been compromised (by hash)

--- a/docs/tables/hibp_paste.md
+++ b/docs/tables/hibp_paste.md
@@ -4,6 +4,8 @@ A "paste" is information that has been "pasted" to a publicly facing website des
 
 HIBP searches through pastes that are broadcast by the accounts in the Paste Sources Twitter list and reported as having emails that are a potential indicator of a breach. Finding an email address in a paste does not immediately mean it has been disclosed as the result of a breach. Review the paste and determine if your account has been compromised then take appropriate action such as changing passwords.
 
+This table requires an API key to be configured in the `hibp.spc` file.
+
 ## Examples
 
 ### List pastes where `billy@example.com` was included in the paste

--- a/hibp/client.go
+++ b/hibp/client.go
@@ -62,3 +62,31 @@ func createClient(ctx context.Context, apiKey string) *hibp.Client {
 	cl := hibp.New(clientOptions...)
 	return &cl
 }
+
+// Create a client without an API key
+// Certain tables like hibp_password do not require an API key
+func getHibpClientWithoutAPIKey(ctx context.Context, d *plugin.QueryData) (*hibp.Client, error) {
+	// Try to load client from cache
+	if cachedData, ok := d.ConnectionManager.Cache.Get(constants.CacheKeyHibpClient); ok {
+		return cachedData.(*hibp.Client), nil
+	}
+
+	// create the hibp client without API key
+	client := createClientWithoutAPIKey(ctx)
+
+	// save client in cache
+	d.ConnectionManager.Cache.Set(constants.CacheKeyHibpClient, client)
+
+	return client, nil
+}
+
+func createClientWithoutAPIKey(ctx context.Context) *hibp.Client {
+	clientOptions := []hibp.Option{
+		hibp.WithUserAgent("Turbot Steampipe (+https://steampipe.io)"),
+		hibp.WithHTTPTimeout(3 * time.Second),
+		hibp.WithRateLimitSleep(),
+	}
+
+	cl := hibp.New(clientOptions...)
+	return &cl
+}

--- a/hibp/client.go
+++ b/hibp/client.go
@@ -33,7 +33,6 @@ func getHibpClient(ctx context.Context, d *plugin.QueryData) (*hibp.Client, erro
 
 // getKeysFromConfig fetches the apiKey from the connection config
 // falls back to the environment variables if it cannot find one in the config
-// returns an error if api key could not be resolved
 func getKeysFromConfig(ctx context.Context, d *plugin.QueryData) (apiKey string, _ error) {
 	config := GetConfig(d.Connection)
 

--- a/hibp/client.go
+++ b/hibp/client.go
@@ -43,7 +43,7 @@ func getKeysFromConfig(ctx context.Context, d *plugin.QueryData) (apiKey string,
 		apiKey = *config.ApiKey
 	}
 
-	// Return an empty value for tables like `hibp_password` and `hibp_breach` tables since they do not need APIs
+	// Return nil since some tables like `hibp_password` and `hibp_breach` don't need an API key
 	if len(apiKey) == 0 {
 		return "", nil
 	}

--- a/hibp/table_hibp_password.go
+++ b/hibp/table_hibp_password.go
@@ -38,7 +38,7 @@ func tableHIBPPassword() *plugin.Table {
 
 func listPasswords(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
-	client, err := getHibpClientWithoutAPIKey(ctx, d)
+	client, err := getHibpClient(ctx, d)
 
 	if err != nil {
 		return nil, err

--- a/hibp/table_hibp_password.go
+++ b/hibp/table_hibp_password.go
@@ -37,7 +37,8 @@ func tableHIBPPassword() *plugin.Table {
 }
 
 func listPasswords(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := getHibpClient(ctx, d)
+
+	client, err := getHibpClientWithoutAPIKey(ctx, d)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
