### PR TITLE
Fixed the invalid Go module path of the plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module steampipe-plugin-hibp
+module github.com/turbot/steampipe-plugin-hibp
 
 go 1.21
 

--- a/hibp/client.go
+++ b/hibp/client.go
@@ -3,7 +3,7 @@ package hibp
 import (
 	"context"
 	"os"
-	"steampipe-plugin-hibp/constants"
+	"github.com/turbot/steampipe-plugin-hibp/constants"
 	"time"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"steampipe-plugin-hibp/hibp"
+	"github.com/turbot/steampipe-plugin-hibp/hibp"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
